### PR TITLE
Fix huggingface tutorial to run with 23.05 containers

### DIFF
--- a/HuggingFace/README.md
+++ b/HuggingFace/README.md
@@ -88,7 +88,7 @@ To run this example open two terminals and use the following commands:
 mv python_model_repository model_repository
 
 # Pull and run the Triton container & replace yy.mm 
-# with year and month of release. Eg. 22.12
+# with year and month of release. Eg. 23.05
 docker run --gpus=all -it --shm-size=256m --rm -p8000:8000 -p8001:8001 -p8002:8002 -v ${PWD}:/workspace/ -v ${PWD}/model_repository:/models nvcr.io/nvidia/tritonserver:yy.mm-py3 bash
 
 # Install dependencies
@@ -115,7 +115,7 @@ Before the specifics around deploying the models can be discussed, the first ste
   
 ```
 # Pull the PyTorch Container from NGC
-docker run -it --gpus=all -v ${PWD}:/workspace nvcr.io/nvidia/pytorch:22.12-py3
+docker run -it --gpus=all -v ${PWD}:/workspace nvcr.io/nvidia/pytorch:23.05-py3
 
 # Install dependencies
 pip install transformers
@@ -156,7 +156,7 @@ mv vit/model.onnx model_repository/vit/1/
 mkdir model_repository/ensemble_model/1
 
 # Pull and run the Triton container & replace yy.mm 
-# with year and month of release. Eg. 22.12
+# with year and month of release. Eg. 23.05
 docker run --gpus=all -it --shm-size=256m --rm -p8000:8000 -p8001:8001 -p8002:8002 -v ${PWD}:/workspace/ -v ${PWD}/model_repository:/models nvcr.io/nvidia/tritonserver:yy.mm-py3 bash
 
 # Install dependencies

--- a/HuggingFace/client.py
+++ b/HuggingFace/client.py
@@ -25,7 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
-import time
 from tritonclient.utils import *
 from PIL import Image
 import tritonclient.http as httpclient

--- a/HuggingFace/python_model_repository/python_vit/1/model.py
+++ b/HuggingFace/python_model_repository/python_vit/1/model.py
@@ -24,14 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import torch
 import numpy as np
 import triton_python_backend_utils as pb_utils
-from transformers import ViTFeatureExtractor, ViTModel
+from transformers import ViTImageProcessor, ViTModel
 
 class TritonPythonModel:
     def initialize(self, args):
-        self.feature_extractor = ViTFeatureExtractor.from_pretrained('google/vit-base-patch16-224-in21k').to("cuda")
-        self.model = ViTModel.from_pretrained("google/vit-base-patch16-224-in21k").to("cuda")
+        self.feature_extractor = ViTImageProcessor.from_pretrained('google/vit-base-patch16-224-in21k')
+        self.model = ViTModel.from_pretrained("google/vit-base-patch16-224-in21k")
 
     def execute(self, requests):
         responses = []
@@ -44,8 +45,8 @@ class TritonPythonModel:
 
             inference_response = pb_utils.InferenceResponse(output_tensors=[
                 pb_utils.Tensor(
-                    "label",
-                    outputs.last_hidden_state.numpy()
+                    "last_hidden_state",
+                    outputs.last_hidden_state.detach().numpy()
                 )
             ])
             responses.append(inference_response)


### PR DESCRIPTION
Ran into serveral issues when running the tutorial with the latest 23.05 triton containers. This PR fixes these errros
```
/usr/local/lib/python3.10/dist-packages/transformers/models/vit/feature_extraction_vit.py:28: FutureWarning: The class ViTFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please use ViTImageProcessor instead.
```
-> replaced with `ViTImageProcessor`
```
E0621 17:00:13.433654 535 model_lifecycle.cc:626] failed to load 'python_vit' version 1: Internal: AttributeError: 'ViTImageProcessor' object has no attribute 'to'
```
-> removed to as it doesn't seem to be required to run inference on the GPU.
```
tritonclient.utils.InferenceServerException: [400] Failed to process the request(s) for model instance 'python_vit_0', message: RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
```
-> add `.detach().numpy()`

Also fixes the output name to avoid the inference result being `None` on the client side.

The expected output on the client is now
```
python3 client.py --model_name "python_vit"
(1, 197, 768)
```