### PR TITLE
Lower default temperature in vLLM example

### DIFF
--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -69,7 +69,7 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name):
 
 async def main(FLAGS):
     model_name = "vllm"
-    sampling_parameters = {"temperature": "0.8", "top_p": "0.95"}
+    sampling_parameters = {"temperature": "0.1", "top_p": "0.95"}
     stream = FLAGS.streaming_mode
     with open(FLAGS.input_prompts, "r") as file:
         print(f"Loading inputs from `{FLAGS.input_prompts}`...")


### PR DESCRIPTION
A lower default temperature appears to decrease the chance of vulgar or inappropriate responses in our example, and makes them more deterministic. 

I think a lower temp is a better default example behavior, and users familiar with the parameter can tweak it if they wish.