### PR TITLE
Refactor vLLM guide

### DIFF
--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -136,7 +136,7 @@ You can inspect the contents of the `results.txt` for the response from the serv
 flag can be used with the client to increase the load on the server by looping through the list of
 provided prompts in [`prompts.txt`](prompts.txt).
 
-When you run the client in verbose mode - with `--verbose` flag, the client will print more details
+When you run the client in verbose mode with the `--verbose` flag, the client will print more details
 about the request/response transactions.
 
 ## Limitations

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -34,18 +34,25 @@ The following tutorial demonstrates how to deploy a simple
 Triton Inference Server using Triton's [Python backend](https://github.com/triton-inference-server/python_backend) and the
 [vLLM](https://github.com/vllm-project/vllm) library.
 
-*NOTE*: The tutorial is intended to be a reference example only. It is a work in progress with [known limitations](#limitations).
+*NOTE*: The tutorial is intended to be a reference example only. It is a work in progress with
+[known limitations](#limitations).
 
 
 ## Step 1: Build a Custom Execution Environment with vLLM and other Dependencies
 
-Running vLLM within Triton container requires us to provide [custom execution environment](https://github.com/triton-inference-server/python_backend#creating-custom-execution-environments) with vLLM and other package dependencies. The provided script should build the package environment for you which will be used to load the model in Triton.
+Running vLLM within Triton container requires us to provide
+[custom execution environment](https://github.com/triton-inference-server/python_backend#creating-custom-execution-environments)
+with vLLM and other package dependencies. The provided script should build the package environment
+for you which will be used to load the model in Triton.
 
 ```
-docker run --gpus all -it --rm -v ${PWD}:/work -w /work nvcr.io/nvidia/tritonserver:23.08-py3 ./gen_vllm_env.sh
+docker run --gpus all -it --rm -p 8000:8000 -p 8001:8001 -p 8002:8002 --shm-size=8G --ulimit memlock=-1 --ulimit stack=67108864 -v ${PWD}:/work -w /work nvcr.io/nvidia/tritonserver:23.08-py3 bash
+./gen_vllm_env.sh
 ```
 
-This step might take a while to build the environment packages. Once complete, the provided sample [model_repository](model_repository) will be populated with `triton_python_backend_stub` and `vllm_env.tar.gz`.
+This step might take a while to build the environment packages. Once complete, the provided sample
+[model_repository](model_repository) will be populated with
+`triton_python_backend_stub` and `vllm_env`.
 
 ## Step 2: Set Up Triton Inference Server
 
@@ -58,11 +65,12 @@ model_repository/
     |-- config.pbtxt
     |-- triton_python_backend_stub
     |-- vllm_engine_args.json
-    `-- vllm_env.tar.gz
+    `-- vllm_env
 
 ```
 
-A sample model repository for deploying `facebook/opt-125m` using vLLM in Triton is included with this demo as `model_repository` directory. The content of `vllm_engine_args.json` is:
+A sample model repository for deploying `facebook/opt-125m` using vLLM in Triton is included with
+this demo as `model_repository` directory. The content of `vllm_engine_args.json` is:
 
 ```json
 {
@@ -70,19 +78,26 @@ A sample model repository for deploying `facebook/opt-125m` using vLLM in Triton
     "disable_log_requests": "true"
 }
 ```
-This file can be modified to provide further settings to the vLLM engine. See vLLM [AsyncEngineArgs](https://github.com/vllm-project/vllm/blob/32b6816e556f69f1672085a6267e8516bcb8e622/vllm/engine/arg_utils.py#L165) and [EngineArgs](https://github.com/vllm-project/vllm/blob/32b6816e556f69f1672085a6267e8516bcb8e622/vllm/engine/arg_utils.py#L11) for supported key-value pairs.
+This file can be modified to provide further settings to the vLLM engine. See vLLM
+[AsyncEngineArgs](https://github.com/vllm-project/vllm/blob/32b6816e556f69f1672085a6267e8516bcb8e622/vllm/engine/arg_utils.py#L165)
+and
+[EngineArgs](https://github.com/vllm-project/vllm/blob/32b6816e556f69f1672085a6267e8516bcb8e622/vllm/engine/arg_utils.py#L11)
+for supported key-value pairs.
 
-*Note*: vLLM greedily consume upto 90% of the GPU's memory under default settings. You can provide appropriate fields like `gpu_memory_utilization` and other settings via [`vllm_engine_args.json`](model_repository/vllm/vllm_engine_args.json).
+*Note*: vLLM greedily consume upto 90% of the GPU's memory under default settings. You can provide
+appropriate fields like `gpu_memory_utilization` and other settings via
+[`vllm_engine_args.json`](model_repository/vllm/vllm_engine_args.json).
 
-Read through the documentation in [`model.py`](model_repository/vllm/1/model.py) to understand how to configure this sample for your use-case.
+Read through the documentation in [`model.py`](model_repository/vllm/1/model.py) to understand how
+to configure this sample for your use-case.
 
-Start the server like below:
+Using the container you already started, run the following command:
 
 ```
-docker run -p 8000:8000 -p 8001:8001 -p 8002:8002 --gpus all -it --rm --shm-size=8G --ulimit memlock=-1 --ulimit stack=67108864 -v ${PWD}/model_repository:/models nvcr.io/nvidia/tritonserver:23.08-py3 tritonserver --model-store=/models
+tritonserver --model-store=model_repository
 ```
 
-Upon successful start of the server, you can see the following in the end.
+Upon successful start of the server, you should see the following at the end of the logs.
 
 ```
 I0901 23:39:08.729123 1 grpc_server.cc:2451] Started GRPCInferenceService at 0.0.0.0:8001
@@ -92,7 +107,7 @@ I0901 23:39:08.772522 1 http_server.cc:187] Started Metrics Service at 0.0.0.0:8
 
 ## Step 3: Using a Triton Client to Query the Server
 
-We will run the client within Triton's SDK container to issue multiple async requests using
+We will run the client within Triton's SDK container to issue multiple async requests using the
 [gRPC asyncio client](https://github.com/triton-inference-server/client/blob/main/src/python/library/tritonclient/grpc/aio/__init__.py)
 library.
 
@@ -100,13 +115,14 @@ library.
 docker run -it --net=host -v ${PWD}:/workspace/ nvcr.io/nvidia/tritonserver:23.08-py3-sdk bash
 ```
 
-Within the container, run the [`client.py`](client.py) as:
+Within the container, run [`client.py`](client.py) with:
 
 ```
 python3 client.py
 ```
 
-The client reads prompts from [prompts.txt](prompts.txt) file, sends them to Triton server for inference and stores the results into a file named `results.txt` by default.
+The client reads prompts from [prompts.txt](prompts.txt) file, sends them to Triton server for
+inference, and stores the results into a file named `results.txt` by default.
 
 The output of the client should look like below:
 
@@ -116,9 +132,12 @@ Storing results into `results.txt`...
 PASS: vLLM example
 ```
 
-You can inspect the contents of the `results.txt` for the response from the server. `--iterations` flag can be used with the client to increase the load on the server by looping through the list of provided prompts in [`prompts.txt`](prompts.txt).
+You can inspect the contents of the `results.txt` for the response from the server. `--iterations`
+flag can be used with the client to increase the load on the server by looping through the list of
+provided prompts in [`prompts.txt`](prompts.txt).
 
-When you run the client in verbose mode - with `--verbose` flag, the client will print more details about the request/response transactions.
+When you run the client in verbose mode - with `--verbose` flag, the client will print more details
+about the request/response transactions.
 
 ## Limitations
 

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -97,7 +97,7 @@ Using the container you already started, run the following command:
 tritonserver --model-store=model_repository
 ```
 
-Upon successful start of the server, you should see the following at the end of the logs.
+Upon successful start of the server, you should see the following at the end of the output.
 
 ```
 I0901 23:39:08.729123 1 grpc_server.cc:2451] Started GRPCInferenceService at 0.0.0.0:8001

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -121,7 +121,7 @@ Within the container, run [`client.py`](client.py) with:
 python3 client.py
 ```
 
-The client reads prompts from [prompts.txt](prompts.txt) file, sends them to Triton server for
+The client reads prompts from the [prompts.txt](prompts.txt) file, sends them to Triton server for
 inference, and stores the results into a file named `results.txt` by default.
 
 The output of the client should look like below:

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -132,7 +132,7 @@ Storing results into `results.txt`...
 PASS: vLLM example
 ```
 
-You can inspect the contents of the `results.txt` for the response from the server. `--iterations`
+You can inspect the contents of the `results.txt` for the response from the server. The `--iterations`
 flag can be used with the client to increase the load on the server by looping through the list of
 provided prompts in [`prompts.txt`](prompts.txt).
 

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -38,7 +38,7 @@ Triton Inference Server using Triton's [Python backend](https://github.com/trito
 [known limitations](#limitations).
 
 
-## Step 1: Build a Custom Execution Environment with vLLM and other Dependencies
+## Step 1: Build a Custom Execution Environment With vLLM and Other Dependencies
 
 Running vLLM within Triton container requires us to provide
 [custom execution environment](https://github.com/triton-inference-server/python_backend#creating-custom-execution-environments)

--- a/Quick_Deploy/vLLM/gen_vllm_env.sh
+++ b/Quick_Deploy/vLLM/gen_vllm_env.sh
@@ -50,7 +50,7 @@ rm -rf $ENV_DIR $STUB_FILE
 
 # Install and setup conda environment
 FILE_NAME="Miniconda3-latest-Linux-x86_64.sh"
-rm -rf ./miniconda  $FILE_NAME
+rm -rf ./miniconda $FILE_NAME
 wget https://repo.anaconda.com/miniconda/$FILE_NAME
 
 # Install miniconda in silent mode

--- a/Quick_Deploy/vLLM/gen_vllm_env.sh
+++ b/Quick_Deploy/vLLM/gen_vllm_env.sh
@@ -38,8 +38,9 @@ RELEASE_TAG="r${NVIDIA_TRITON_SERVER_VERSION}"
 ENV_DIR="./model_repository/vllm/vllm_env/"
 STUB_FILE="./model_repository/vllm/triton_python_backend_stub"
 
+# If targets aready exist, print a message and exit.
 if [ -d "$ENV_DIR" ] && [ -f "$STUB_FILE" ]; then
-    echo "The conda environment directory and stub directories already exist."
+    echo "The conda environment directory and Python backend stubs already exist."
     echo "Exiting environment set-up."
     exit 0
 fi

--- a/Quick_Deploy/vLLM/gen_vllm_env.sh
+++ b/Quick_Deploy/vLLM/gen_vllm_env.sh
@@ -75,15 +75,13 @@ git clone https://github.com/triton-inference-server/python_backend -b $RELEASE_
 cmake -DTRITON_ENABLE_GPU=ON -DTRITON_BACKEND_REPO_TAG=$RELEASE_TAG -DTRITON_COMMON_REPO_TAG=$RELEASE_TAG -DTRITON_CORE_REPO_TAG=$RELEASE_TAG ../ && \
 make -j18 triton-python-backend-stub)
 
-conda-pack -n vllm_env -o vllm_env.tar.gz
-chmod 755 vllm_env.tar.gz
-
-mv vllm_env.tar.gz ./model_repository/vllm/
 mv python_backend/builddir/triton_python_backend_stub ./model_repository/vllm/
+
+cp -r $CONDA_PREFIX/lib/python3.10/site-packages/conda_pack/scripts/posix/activate $CONDA_PREFIX/bin/
 
 conda deactivate
 
 
 # Clean-up
-rm -rf ./miniconda  $file_name
+rm -rf  $file_name
 rm -rf python_backend

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -41,7 +41,7 @@ model_transaction_policy {
 
 parameters: {
   key: "EXECUTION_ENV_PATH",
-  value: {string_value: "/work/miniconda/envs/vllm_env"}
+  value: {string_value: "$$TRITON_MODEL_DIRECTORY/vllm_env"}
 }
 
 input [

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -41,7 +41,7 @@ model_transaction_policy {
 
 parameters: {
   key: "EXECUTION_ENV_PATH",
-  value: {string_value: "$$TRITON_MODEL_DIRECTORY/vllm_env.tar.gz"}
+  value: {string_value: "/work/miniconda/envs/vllm_env"}
 }
 
 input [


### PR DESCRIPTION
- Use uncompressed conda environment to reduce time to conda-pack and to reduce need for Triton to unpack (from Ryan McCormick's testing, this shrinks the model load time from 170 seconds to 13 seconds).
- Remove unnecessary Nsight Systems files from conda environment
- Use one container for steps 1 and 2 for simplicity (script will now check if step 1 is complete and exit if so)

Tested locally.

If step 1 is re-run:
<img width="466" alt="image" src="https://github.com/triton-inference-server/tutorials/assets/58150256/b2d4429b-4a0a-496a-8300-03ab9225db58">

After following steps:
<img width="1349" alt="image" src="https://github.com/triton-inference-server/tutorials/assets/58150256/d05b210f-fddb-48af-8f37-807a1618e621">
<img width="328" alt="image" src="https://github.com/triton-inference-server/tutorials/assets/58150256/82e24ef3-9726-4ee5-ac3e-1d46462eaa2e">
