### PR TITLE
Resolve unsupported InferenceRequest parameters in BLS

### DIFF
--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -29,6 +29,7 @@ import asyncio
 import queue
 import sys
 from os import system
+import json
 
 import numpy as np
 import tritonclient.grpc.aio as grpcclient
@@ -53,6 +54,12 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name):
     inputs.append(grpcclient.InferInput("STREAM", [1], "BOOL"))
     inputs[-1].set_data_from_numpy(stream_data)
 
+    sampling_parameters_data = np.array(
+        [json.dumps(sampling_parameters).encode("utf-8")], dtype=np.object_
+    )
+    inputs.append(grpcclient.InferInput("SAMPLING_PARAMETERS", [1], "BYTES"))
+    inputs[-1].set_data_from_numpy(sampling_parameters_data)
+
     # Add requested outputs
     outputs = []
     outputs.append(grpcclient.InferRequestedOutput("TEXT"))
@@ -62,8 +69,7 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name):
         "model_name": model_name,
         "inputs": inputs,
         "outputs": outputs,
-        "request_id": str(request_id),
-        "parameters": sampling_parameters,
+        "request_id": str(request_id)
     }
 
 

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -159,7 +159,8 @@ class TritonPythonModel:
             request_id = random_uuid()
             prompt = pb_utils.get_input_tensor_by_name(request, "PROMPT").as_numpy()[0]
             stream = pb_utils.get_input_tensor_by_name(request, "STREAM").as_numpy()[0]
-            sampling_params_dict = self.get_sampling_params_dict(request.parameters())
+            parameters = pb_utils.get_input_tensor_by_name(request, "SAMPLING_PARAMETERS").as_numpy()[0].decode("utf-8")
+            sampling_params_dict = self.get_sampling_params_dict(parameters)
             sampling_params = SamplingParams(**sampling_params_dict)
 
             last_output = None

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -54,6 +54,11 @@ input [
     name: "STREAM"
     data_type: TYPE_BOOL
     dims: [ 1 ]
+  },
+  {
+    name: "SAMPLING_PARAMETERS"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
   }
 ]
 


### PR DESCRIPTION
## Description

This PR addresses the issue where the VLLM tutorial cannot run in BLS mode. The problem was initially pointed out in the [pb_stub.cc file, line 1426](https://github.com/triton-inference-server/python_backend/blob/main/src/pb_stub.cc#L1426).

## Changes
Moved parameters to the `input` field instead of using the `parameter` field in `InferenceRequest`.