### PR TITLE
Support input and parameter approaches for vLLM tutorial

### DIFF
--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -29,6 +29,7 @@ import asyncio
 import queue
 import sys
 from os import system
+import json
 
 import numpy as np
 import tritonclient.grpc.aio as grpcclient
@@ -53,6 +54,12 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name):
     inputs.append(grpcclient.InferInput("STREAM", [1], "BOOL"))
     inputs[-1].set_data_from_numpy(stream_data)
 
+    sampling_parameters_data = np.array(
+        [json.dumps(sampling_parameters).encode("utf-8")], dtype=np.object_
+    )
+    inputs.append(grpcclient.InferInput("SAMPLING_PARAMETERS", [1], "BYTES"))
+    inputs[-1].set_data_from_numpy(sampling_parameters_data)
+
     # Add requested outputs
     outputs = []
     outputs.append(grpcclient.InferRequestedOutput("TEXT"))
@@ -62,8 +69,7 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name):
         "model_name": model_name,
         "inputs": inputs,
         "outputs": outputs,
-        "request_id": str(request_id),
-        "parameters": sampling_parameters,
+        "request_id": str(request_id)
     }
 
 

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -159,7 +159,17 @@ class TritonPythonModel:
             request_id = random_uuid()
             prompt = pb_utils.get_input_tensor_by_name(request, "PROMPT").as_numpy()[0]
             stream = pb_utils.get_input_tensor_by_name(request, "STREAM").as_numpy()[0]
-            parameters = pb_utils.get_input_tensor_by_name(request, "SAMPLING_PARAMETERS").as_numpy()[0].decode("utf-8")
+
+            # Request parameters are not yet supported via
+            # BLS. Provide an optional mechanism to receive serialized
+            # parameters as an input tensor until support is added
+
+            parameters_input_tensor = pb_utils.get_input_tensor_by_name(request, "SAMPLING_PARAMETERS")
+            if parameters_input_tensor:
+                parameters = parameters_input_tensor.as_numpy()[0].decode("utf-8")
+            else:
+                parameters = request.parameters()
+
             sampling_params_dict = self.get_sampling_params_dict(parameters)
             sampling_params = SamplingParams(**sampling_params_dict)
 

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -159,7 +159,8 @@ class TritonPythonModel:
             request_id = random_uuid()
             prompt = pb_utils.get_input_tensor_by_name(request, "PROMPT").as_numpy()[0]
             stream = pb_utils.get_input_tensor_by_name(request, "STREAM").as_numpy()[0]
-            sampling_params_dict = self.get_sampling_params_dict(request.parameters())
+            parameters = pb_utils.get_input_tensor_by_name(request, "SAMPLING_PARAMETERS").as_numpy()[0].decode("utf-8")
+            sampling_params_dict = self.get_sampling_params_dict(parameters)
             sampling_params = SamplingParams(**sampling_params_dict)
 
             last_output = None

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -49,6 +49,11 @@ input [
     name: "STREAM"
     data_type: TYPE_BOOL
     dims: [ 1 ]
+  },
+  {
+    name: "SAMPLING_PARAMETERS"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
   }
 ]
 

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -54,6 +54,7 @@ input [
     name: "SAMPLING_PARAMETERS"
     data_type: TYPE_STRING
     dims: [ 1 ]
+    optional: true
   }
 ]
 


### PR DESCRIPTION
Duplicate of https://github.com/triton-inference-server/tutorials/pull/45.

Combines commits from @tonywang10101 and @nnshah1 into one PR that supports both the input and parameter approaches for vLLM.