### PR TITLE
Minor vllm UX improvements

### DIFF
--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -41,29 +41,29 @@ def create_request(prompt, stream, request_id, sampling_parameters, model_name, 
     inputs = []
     prompt_data = np.array([prompt.encode("utf-8")], dtype=np.object_)
     try:
-        inputs.append(grpcclient.InferInput("PROMPT", [1], "BYTES"))
+        inputs.append(grpcclient.InferInput("prompt", [1], "BYTES"))
         inputs[-1].set_data_from_numpy(prompt_data)
     except Exception as e:
         print(f"Encountered an error {e}")
 
     stream_data = np.array([stream], dtype=bool)
-    inputs.append(grpcclient.InferInput("STREAM", [1], "BOOL"))
+    inputs.append(grpcclient.InferInput("stream", [1], "BOOL"))
     inputs[-1].set_data_from_numpy(stream_data)
 
     # Request parameters are not yet supported via BLS. Provide an
     # optional mechanism to send serialized parameters as an input
     # tensor until support is added
-    
+
     if send_parameters_as_tensor:
         sampling_parameters_data = np.array(
             [json.dumps(sampling_parameters).encode("utf-8")], dtype=np.object_
         )
-        inputs.append(grpcclient.InferInput("SAMPLING_PARAMETERS", [1], "BYTES"))
+        inputs.append(grpcclient.InferInput("sampling_parameters", [1], "BYTES"))
         inputs[-1].set_data_from_numpy(sampling_parameters_data)
 
     # Add requested outputs
     outputs = []
-    outputs.append(grpcclient.InferRequestedOutput("TEXT"))
+    outputs.append(grpcclient.InferRequestedOutput("text"))
 
     # Issue the asynchronous sequence inference.
     return {
@@ -113,7 +113,7 @@ async def main(FLAGS):
                 if error:
                     print(f"Encountered error while processing: {error}")
                 else:
-                    output = result.as_numpy("TEXT")
+                    output = result.as_numpy("text")
                     for i in output:
                         results_dict[result.get_response().id].append(i)
 

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -123,31 +123,25 @@ class TritonPythonModel:
         This functions parses the dictionary values into their
         expected format.
         """
-        # Opinionated defaults for out-of-the-box experience if left unspecified.
-        # These will be overwritten below if provided.
-        sampling_params = {
-          "temperature": 0.1
-        }
-
         params_dict = json.loads(params_json)
 
         # Special parsing for the supported sampling parameters
         bool_keys = ["ignore_eos", "skip_special_tokens", "use_beam_search"]
         for k in bool_keys:
             if k in params_dict:
-                sampling_params[k] = bool(params_dict[k])
+                params_dict[k] = bool(params_dict[k])
 
         float_keys = ["frequency_penalty", "length_penalty", "presence_penalty", "temperature", "top_p"]
         for k in float_keys:
             if k in params_dict:
-                sampling_params[k] = float(params_dict[k])
+                params_dict[k] = float(params_dict[k])
 
         int_keys = ["best_of", "max_tokens", "n", "top_k"]
         for k in int_keys:
             if k in params_dict:
-                sampling_params[k] = int(params_dict[k])
+                params_dict[k] = int(params_dict[k])
 
-        return sampling_params
+        return params_dict
 
     def create_response(self, vllm_output):
         """

--- a/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
+++ b/Quick_Deploy/vLLM/model_repository/vllm/config.pbtxt
@@ -41,17 +41,18 @@ model_transaction_policy {
 
 input [
   {
-    name: "PROMPT"
+    name: "prompt"
     data_type: TYPE_STRING
     dims: [ 1 ]
   },
   {
-    name: "STREAM"
+    name: "stream"
     data_type: TYPE_BOOL
     dims: [ 1 ]
+    optional: true
   },
   {
-    name: "SAMPLING_PARAMETERS"
+    name: "sampling_parameters"
     data_type: TYPE_STRING
     dims: [ 1 ]
     optional: true
@@ -60,7 +61,7 @@ input [
 
 output [
   {
-    name: "TEXT"
+    name: "text"
     data_type: TYPE_STRING
     dims: [ -1 ]
   }


### PR DESCRIPTION
Changes
- Make input tensor names lowercase, this makes the new REST API usage between Triton and vllm API server almost identical for comparison
- Make stream input optional - it's annoying to specify when just playing with the models
- ~~Add model-side default temperature as well to improve results when using `curl` or clients other than the `client.py` provided with the example~~

vllm API server generate endpoint:
```
curl -s localhost:8000/generate -d '{ "prompt": "San Francisco is a ", "temperature": 0 }'
```
Triton generate endpoint:
```
curl -s localhost:8000/v2/models/vllm/generate -d '{ "prompt": "San Francisco is a ", "temperature": 0 }'
```

Follow-up Action Items:
- @nv-hwoo may need to update PA vllm example
- @rmccorm4 update generate endpoint test - names and optional stream
- @rmccorm4 @pskiran1 update vllm test if necessary, may not be needed since client.py is updated