### PR TITLE
Add request cancellation support to vLLM tutorial

### DIFF
--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -186,13 +186,13 @@ class TritonPythonModel:
             async for output in self.llm_engine.generate(
                 str(prompt), sampling_params, request_id
             ):
+                if response_sender.is_cancelled():
+                    await self.llm_engine.abort(request_id)
+                    break
                 if stream:
                     response_sender.send(self.create_response(output))
                 else:
                     last_output = output
-                if response_sender.is_cancelled():
-                    await self.llm_engine.abort(request_id)
-                    break
 
             if not stream:
                 response_sender.send(self.create_response(last_output))

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -190,6 +190,9 @@ class TritonPythonModel:
                     response_sender.send(self.create_response(output))
                 else:
                     last_output = output
+                if response_sender.is_cancelled():
+                    await self.llm_engine.abort(request_id)
+                    break
 
             if not stream:
                 response_sender.send(self.create_response(last_output))


### PR DESCRIPTION
Abort and break vLLM generate loop if the request is cancelled.