### PR TITLE
Decode bytes input to utf-8 string before passing to vllm engine

### DIFF
--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -167,6 +167,8 @@ class TritonPythonModel:
         try:
             request_id = random_uuid()
             prompt = pb_utils.get_input_tensor_by_name(request, "PROMPT").as_numpy()[0]
+            if isinstance(prompt, bytes):
+                prompt = prompt.decode("utf-8")
             stream = pb_utils.get_input_tensor_by_name(request, "STREAM").as_numpy()[0]
 
             # Request parameters are not yet supported via

--- a/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
+++ b/Quick_Deploy/vLLM/model_repository/vllm/1/model.py
@@ -186,7 +186,7 @@ class TritonPythonModel:
 
             last_output = None
             async for output in self.llm_engine.generate(
-                str(prompt), sampling_params, request_id
+                prompt, sampling_params, request_id
             ):
                 if stream:
                     response_sender.send(self.create_response(output))


### PR DESCRIPTION
- Removes nested bytestring of prompt embedded in responses
- Improves outputs - cleaner and more coherent. It was probably a bug to send bytestring to vllm engine.
