### PR TITLE
Refactor vLLM tutorial to use iterable client 

### DIFF
--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -1,3 +1,29 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import argparse
 import asyncio
 import queue

--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -54,6 +54,7 @@ class LLMClient:
 
     async def stream_infer(self, prompts, sampling_parameters, model_name):
         try:
+            # Start streaming
             response_iterator = self._client.stream_infer(
                 inputs_iterator=self.async_request_iterator(prompts, sampling_parameters, model_name),
                 stream_timeout=self._flags.stream_timeout,
@@ -68,6 +69,7 @@ class LLMClient:
         # Clear results in between process_stream calls
         self.results_dict = []
         
+        # Read response from the stream
         async for response in self.stream_infer(prompts, sampling_parameters, model_name):
             result, error = response
             if error:
@@ -76,6 +78,7 @@ class LLMClient:
                 output = result.as_numpy("TEXT")
                 for i in output:
                     self._results_dict[result.get_response().id].append(i)
+
     async def run(self):
         model_name = "vllm"
         sampling_parameters = {"temperature": "0.1", "top_p": "0.95"}
@@ -139,6 +142,7 @@ class LLMClient:
             "request_id": str(request_id),
             "parameters": sampling_parameters
         }
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -97,8 +97,9 @@ class LLMClient:
             print(f"Storing results into `{self._flags.results_file}`...")
 
         if self._flags.verbose:
-            print(f"\nContents of `{self._flags.results_file}` ===>")
-            system(f"cat {self._flags.results_file}")
+            with open(self._flags.results_file, "r") as file:
+                print(f"\nContents of `{self._flags.results_file}` ===>")
+                print(file.read())
 
         print("PASS: vLLM example")
 

--- a/Quick_Deploy/vLLM/client.py
+++ b/Quick_Deploy/vLLM/client.py
@@ -1,29 +1,3 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#  * Neither the name of NVIDIA CORPORATION nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 import argparse
 import asyncio
 import queue
@@ -35,106 +9,110 @@ import numpy as np
 import tritonclient.grpc.aio as grpcclient
 from tritonclient.utils import *
 
+class LLMClient:
+    def __init__(self, flags: argparse.Namespace):
+        self._client = grpcclient.InferenceServerClient(url=flags.url, verbose=flags.verbose)
+        self._flags = flags
+        self._loop = asyncio.get_event_loop()
+        self._results_dict = {}
 
-
-def create_request(prompt, stream, request_id, sampling_parameters, model_name, send_parameters_as_tensor=True):
-    inputs = []
-    prompt_data = np.array([prompt.encode("utf-8")], dtype=np.object_)
-    try:
-        inputs.append(grpcclient.InferInput("PROMPT", [1], "BYTES"))
-        inputs[-1].set_data_from_numpy(prompt_data)
-    except Exception as e:
-        print(f"Encountered an error {e}")
-
-    stream_data = np.array([stream], dtype=bool)
-    inputs.append(grpcclient.InferInput("STREAM", [1], "BOOL"))
-    inputs[-1].set_data_from_numpy(stream_data)
-
-    # Request parameters are not yet supported via BLS. Provide an
-    # optional mechanism to send serialized parameters as an input
-    # tensor until support is added
-    
-    if send_parameters_as_tensor:
-        sampling_parameters_data = np.array(
-            [json.dumps(sampling_parameters).encode("utf-8")], dtype=np.object_
-        )
-        inputs.append(grpcclient.InferInput("SAMPLING_PARAMETERS", [1], "BYTES"))
-        inputs[-1].set_data_from_numpy(sampling_parameters_data)
-
-    # Add requested outputs
-    outputs = []
-    outputs.append(grpcclient.InferRequestedOutput("TEXT"))
-
-    # Issue the asynchronous sequence inference.
-    return {
-        "model_name": model_name,
-        "inputs": inputs,
-        "outputs": outputs,
-        "request_id": str(request_id),
-        "parameters": sampling_parameters
-    }
-
-
-async def main(FLAGS):
-    model_name = "vllm"
-    sampling_parameters = {"temperature": "0.1", "top_p": "0.95"}
-    stream = FLAGS.streaming_mode
-    with open(FLAGS.input_prompts, "r") as file:
-        print(f"Loading inputs from `{FLAGS.input_prompts}`...")
-        prompts = file.readlines()
-
-    results_dict = {}
-
-    async with grpcclient.InferenceServerClient(
-        url=FLAGS.url, verbose=FLAGS.verbose
-    ) as triton_client:
-        # Request iterator that yields the next request
-        async def async_request_iterator():
-            try:
-                for iter in range(FLAGS.iterations):
-                    for i, prompt in enumerate(prompts):
-                        prompt_id = FLAGS.offset + (len(prompts) * iter) + i
-                        results_dict[str(prompt_id)] = []
-                        yield create_request(
-                            prompt, stream, prompt_id, sampling_parameters, model_name
-                        )
-            except Exception as error:
-                print(f"caught error in request iterator:  {error}")
-
+    async def async_request_iterator(self, prompts, sampling_parameters, model_name):
         try:
-            # Start streaming
-            response_iterator = triton_client.stream_infer(
-                inputs_iterator=async_request_iterator(),
-                stream_timeout=FLAGS.stream_timeout,
-            )
-            # Read response from the stream
-            async for response in response_iterator:
-                result, error = response
-                if error:
-                    print(f"Encountered error while processing: {error}")
-                else:
-                    output = result.as_numpy("TEXT")
-                    for i in output:
-                        results_dict[result.get_response().id].append(i)
+            for iter in range(self._flags.iterations):
+                for i, prompt in enumerate(prompts):
+                    prompt_id = self._flags.offset + (len(prompts) * iter) + i
+                    self._results_dict[str(prompt_id)] = []
+                    yield self.create_request(prompt, self._flags.streaming_mode, prompt_id, sampling_parameters, model_name)
+        except Exception as error:
+            print(f"Caught an error in the request iterator: {error}")
 
+    async def stream_infer(self, prompts, sampling_parameters, model_name):
+        try:
+            response_iterator = self._client.stream_infer(
+                inputs_iterator=self.async_request_iterator(prompts, sampling_parameters, model_name),
+                stream_timeout=self._flags.stream_timeout,
+            )
+            async for response in response_iterator:
+                yield response
         except InferenceServerException as error:
             print(error)
             sys.exit(1)
 
-    with open(FLAGS.results_file, "w") as file:
-        for id in results_dict.keys():
-            for result in results_dict[id]:
-                file.write(result.decode("utf-8"))
-                file.write("\n")
-            file.write("\n=========\n\n")
-        print(f"Storing results into `{FLAGS.results_file}`...")
+    async def process_stream(self, prompts, sampling_parameters, model_name):
+        # Clear results in between process_stream calls
+        self.results_dict = []
+        
+        async for response in self.stream_infer(prompts, sampling_parameters, model_name):
+            result, error = response
+            if error:
+                print(f"Encountered error while processing: {error}")
+            else:
+                output = result.as_numpy("TEXT")
+                for i in output:
+                    self._results_dict[result.get_response().id].append(i)
+    async def run(self):
+        model_name = "vllm"
+        sampling_parameters = {"temperature": "0.1", "top_p": "0.95"}
+        stream = self._flags.streaming_mode
+        with open(self._flags.input_prompts, "r") as file:
+            print(f"Loading inputs from `{self._flags.input_prompts}`...")
+            prompts = file.readlines()
 
-    if FLAGS.verbose:
-        print(f"\nContents of `{FLAGS.results_file}` ===>")
-        system(f"cat {FLAGS.results_file}")
+        await self.process_stream(prompts, sampling_parameters, model_name)
 
-    print("PASS: vLLM example")
+        with open(self._flags.results_file, "w") as file:
+            for id in self._results_dict.keys():
+                for result in self._results_dict[id]:
+                    file.write(result.decode("utf-8"))
+                    file.write("\n")
+                file.write("\n=========\n\n")
+            print(f"Storing results into `{self._flags.results_file}`...")
 
+        if self._flags.verbose:
+            print(f"\nContents of `{self._flags.results_file}` ===>")
+            system(f"cat {self._flags.results_file}")
+
+        print("PASS: vLLM example")
+
+    def run_async(self):
+        self._loop.run_until_complete(self.run())
+
+    def create_request(self, prompt, stream, request_id, sampling_parameters, model_name, send_parameters_as_tensor=True):
+        inputs = []
+        prompt_data = np.array([prompt.encode("utf-8")], dtype=np.object_)
+        try:
+            inputs.append(grpcclient.InferInput("PROMPT", [1], "BYTES"))
+            inputs[-1].set_data_from_numpy(prompt_data)
+        except Exception as error:
+            print(f"Encountered an error during request creation: {error}")
+
+        stream_data = np.array([stream], dtype=bool)
+        inputs.append(grpcclient.InferInput("STREAM", [1], "BOOL"))
+        inputs[-1].set_data_from_numpy(stream_data)
+
+        # Request parameters are not yet supported via BLS. Provide an
+        # optional mechanism to send serialized parameters as an input
+        # tensor until support is added
+        
+        if send_parameters_as_tensor:
+            sampling_parameters_data = np.array(
+                [json.dumps(sampling_parameters).encode("utf-8")], dtype=np.object_
+            )
+            inputs.append(grpcclient.InferInput("SAMPLING_PARAMETERS", [1], "BYTES"))
+            inputs[-1].set_data_from_numpy(sampling_parameters_data)
+
+        # Add requested outputs
+        outputs = []
+        outputs.append(grpcclient.InferRequestedOutput("TEXT"))
+
+        # Issue the asynchronous sequence inference.
+        return {
+            "model_name": model_name,
+            "inputs": inputs,
+            "outputs": outputs,
+            "request_id": str(request_id),
+            "parameters": sampling_parameters
+        }
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -152,7 +130,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="localhost:8001",
-        help="Inference server URL and it gRPC port. Default is localhost:8001.",
+        help="Inference server URL and its gRPC port. Default is localhost:8001.",
     )
     parser.add_argument(
         "-t",
@@ -199,4 +177,6 @@ if __name__ == "__main__":
         help="Enable streaming mode",
     )
     FLAGS = parser.parse_args()
-    asyncio.run(main(FLAGS))
+    
+    client = LLMClient(FLAGS)
+    client.run_async()


### PR DESCRIPTION
This pull request keeps the vLLM tutorial functionality the same. For simplicity, it refactors the logic to use an iterable client class.

Passes locally:
![image](https://github.com/triton-inference-server/tutorials/assets/58150256/c94f82c4-f895-4651-97cb-b1bb1af53039)

Results:
![image](https://github.com/triton-inference-server/tutorials/assets/58150256/6f3fb560-6c73-4671-a605-45239d67c24f)
