### PR TITLE
Update README.md

### DIFF
--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -55,7 +55,7 @@ required to serve the [facebook/opt-125m](https://huggingface.co/facebook/opt-12
 ```
 mkdir -p model_repository/vllm_model/1
 wget -P model_repository/vllm_model/1 https://raw.githubusercontent.com/triton-inference-server/vllm_backend/main/samples/model_repository/vllm_model/1/model.json
-wget -P model_repository/vllm_model/ https://raw.githubusercontent.com/triton-inference-server/vllm_backend/912896b12d66ac63fc7c0758fc39317985e6bcd5/samples/model_repository/vllm_model/config.pbtxt
+wget -P model_repository/vllm_model/ https://raw.githubusercontent.com/triton-inference-server/vllm_backend/r<xx.yy>/samples/model_repository/vllm_model/config.pbtxt
 ```
 
 The model repository should look like this:

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -55,7 +55,7 @@ required to serve the [facebook/opt-125m](https://huggingface.co/facebook/opt-12
 ```
 mkdir -p model_repository/vllm_model/1
 wget -P model_repository/vllm_model/1 https://raw.githubusercontent.com/triton-inference-server/vllm_backend/main/samples/model_repository/vllm_model/1/model.json
-wget -P model_repository/vllm_model/ https://raw.githubusercontent.com/triton-inference-server/vllm_backend/main/samples/model_repository/vllm_model/config.pbtxt
+wget -P model_repository/vllm_model/ https://raw.githubusercontent.com/triton-inference-server/vllm_backend/912896b12d66ac63fc7c0758fc39317985e6bcd5/samples/model_repository/vllm_model/config.pbtxt
 ```
 
 The model repository should look like this:

--- a/Quick_Deploy/vLLM/README.md
+++ b/Quick_Deploy/vLLM/README.md
@@ -54,9 +54,10 @@ and
 required to serve the [facebook/opt-125m](https://huggingface.co/facebook/opt-125m) model.
 ```
 mkdir -p model_repository/vllm_model/1
-wget -P model_repository/vllm_model/1 https://raw.githubusercontent.com/triton-inference-server/vllm_backend/main/samples/model_repository/vllm_model/1/model.json
+wget -P model_repository/vllm_model/1 https://raw.githubusercontent.com/triton-inference-server/vllm_backend/r<xx.yy>/samples/model_repository/vllm_model/1/model.json
 wget -P model_repository/vllm_model/ https://raw.githubusercontent.com/triton-inference-server/vllm_backend/r<xx.yy>/samples/model_repository/vllm_model/config.pbtxt
 ```
+where <xx.yy> is the version of Triton that you want to use. Please note, that Triton's vLLM container has been introduced starting from 23.10 release.
 
 The model repository should look like this:
 ```


### PR DESCRIPTION
Issue: Following the tutorial, the config.pbtxt that you will download from the main branch is not compatible with the releasecd container (23.10-vllm-python-py3). It will therefore fail at initialize (line 75 of model.py) because it is not going to find the data_type key in output_config.

Solution: Point to previous config.pbtxt while the changes are not released in the next tag at NGC.