### PR TITLE
Updated tutorials/Conceptual_Guide/Part_5-Model_Ensembles

### DIFF
--- a/Conceptual_Guide/Part_5-Model_Ensembles/README.md
+++ b/Conceptual_Guide/Part_5-Model_Ensembles/README.md
@@ -316,7 +316,7 @@ ensemble_scheduling {
 We'll again be launching Triton using docker containers. This time, we'll start an interactive session within the container instead of directly launching the triton server.
 
 ```bash
-docker run --gpus=all -it --shm-size=256m --rm  \
+docker run --gpus=all -it --shm-size=1G --rm  \
   -p8000:8000 -p8001:8001 -p8002:8002 \
   -v ${PWD}:/workspace/ -v ${PWD}/model_repository:/models \
   nvcr.io/nvidia/tritonserver:22.12-py3


### PR DESCRIPTION
Added version folder in ensemble_model in side the model repository.
Changed shm-size from 256m to 1G.
These changes are required to run the ensemble model example on Triton 23.12.