### PR TITLE
fix: trtllm_guide.md

### DIFF
--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -143,6 +143,7 @@ To run our Llama2-7B model, you will need to:
     python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/ensemble/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE}
     python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},engine_dir:${ENGINE_DIR}
     ```
+    Also, ensure that the `gpt_model_type` parameter is set to `inflight_fused_batching`.
 
 3.  Launch Tritonserver
 


### PR DESCRIPTION
Based on https://github.com/triton-inference-server/server/issues/6813#issuecomment-1905106294 and https://github.com/triton-inference-server/tutorials/pull/73, outdated documents may cause misleadings.