### PR TITLE
README tweaks to make version references consistent

### DIFF
--- a/Popular_Models_Guide/StableDiffusion/README.md
+++ b/Popular_Models_Guide/StableDiffusion/README.md
@@ -57,10 +57,10 @@ support matrix](https://docs.nvidia.com/deeplearning/frameworks/support-matrix/i
 ## Building the Triton Inference Server Image
 
 The example is designed based on the
-`nvcr.io/nvidia/tritonserver:YY.MM-py3` docker image and [TensorRT OSS v9.2.0](https://github.com/NVIDIA/TensorRT/releases/tag/v9.2.0).
+`nvcr.io/nvidia/tritonserver:24.01-py3` docker image and [TensorRT OSS v9.2.0](https://github.com/NVIDIA/TensorRT/releases/tag/v9.2.0).
 
 A set of convenience scripts are provided to create a docker image
-based on the `nvcr.io/nvidia/tritonserver:YY.MM-py3` image with the
+based on the `nvcr.io/nvidia/tritonserver:24.01-py3` image with the
 dependencies for the TensorRT Stable Diffusion demo installed.
 
 ### Triton Inference Server + TensorRT OSS
@@ -144,7 +144,7 @@ I0229 20:15:52.125050 749 server.cc:676]
 
 ## Building and Running Stable Diffusion XL
 
-### Start `tritonserver:rYY.MM-diffusion` Container
+### Start Tritonserver Diffusion Container
 
 The following command starts a container and volume mounts the current
 directory as `workspace`.

--- a/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_1_5/config.pbtxt
+++ b/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_1_5/config.pbtxt
@@ -56,6 +56,7 @@ output [
 instance_group [
   {
     kind: KIND_GPU
+    gpus: [0]
   }
 ]
 

--- a/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_1_5/config.pbtxt
+++ b/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_1_5/config.pbtxt
@@ -55,6 +55,7 @@ output [
 
 instance_group [
   {
+    count: 1
     kind: KIND_GPU
     gpus: [0]
   }

--- a/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_xl/config.pbtxt
+++ b/Popular_Models_Guide/StableDiffusion/diffusion-models/stable_diffusion_xl/config.pbtxt
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 backend: "diffusion"
-max_batch_size: 2
+max_batch_size: 1
 
 dynamic_batching {
  max_queue_delay_microseconds: 100000

--- a/Triton_Inference_Server_Python_API/examples/rayserve/README.md
+++ b/Triton_Inference_Server_Python_API/examples/rayserve/README.md
@@ -50,7 +50,7 @@ git clone https://github.com/triton-inference-server/tutorials.git
 cd tutorials/Triton_Inference_Server_Python_API
 ```
 
-### Build `triton-python-api:rYY.MM-diffusion` Image and Stable Diffusion Models
+### Build Tritonserver Image and Stable Diffusion Models
 
 Please note the following command will take many minutes depending on
 your hardware configuration and network connection.


### PR DESCRIPTION
Removed version identifiers from section titles and added them back to full container image names.

We will use branch for -b r24.01 for blog post references (and no full container references)

