### PR TITLE
Llama tutorial update related to 24.04 release

### DIFF
--- a/Popular_Models_Guide/Llama2/deploy_trtllm_llama.sh
+++ b/Popular_Models_Guide/Llama2/deploy_trtllm_llama.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+HF_LLAMA_MODEL=/Llama-2-7b-hf
+UNIFIED_CKPT_PATH=/engines/ckpt/llama/7b/
+ENGINE_DIR=/engines
+CONVERT_CHKPT_SCRIPT=/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py
+# Build the LLaMA 7B model using a single GPU and FP16.
+python3 ${CONVERT_CHKPT_SCRIPT} --model_dir ${HF_LLAMA_MODEL} --output_dir ${UNIFIED_CKPT_PATH} --dtype float16
+trtllm-build --checkpoint_dir ${UNIFIED_CKPT_PATH} --remove_input_padding enable --gpt_attention_plugin float16 --context_fmha enable --gemm_plugin float16 --output_dir ${ENGINE_DIR} --paged_kv_cache enable --max_batch_size 4
+
+# Prepare Triton Inference Server model repository
+cp -R /tensorrtllm_backend/all_models/inflight_batcher_llm /opt/tritonserver/.
+TOKENIZER_DIR=/Llama-2-7b-hf/
+TOKENIZER_TYPE=auto
+DECOUPLED_MODE=false
+MODEL_FOLDER=/opt/tritonserver/inflight_batcher_llm
+MAX_BATCH_SIZE=4
+INSTANCE_COUNT=1
+MAX_QUEUE_DELAY_MS=10000
+FILL_TEMPLATE_SCRIPT=/tensorrtllm_backend/tools/fill_template.py
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/preprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE},preprocessing_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/postprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE},postprocessing_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm_bls/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},bls_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/ensemble/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},engine_dir:${ENGINE_DIR},max_queue_delay_microseconds:${MAX_QUEUE_DELAY_MS},batching_strategy:inflight_fused_batching
+python3 /tensorrtllm_backend/scripts/launch_triton_server.py --world_size=$1 --model_repo=/opt/tritonserver/inflight_batcher_llm

--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -91,7 +91,7 @@ and prepares a Triton model repository:
 ENGINE_DEST_PATH=/engines triton import -m llama-2-7b --backend tensorrtllm
 ```
 
-Please, note that specifying `ENGINE_DEST_PATH` is optional, but recmmended
+Please, note that specifying `ENGINE_DEST_PATH` is optional, but recommended
 if you want to re-use compiled engines in the future.
 
 After successful run of `triton import`, you should see the structure of
@@ -133,7 +133,7 @@ Use the [generate endpoint](https://github.com/triton-inference-server/tensorrtl
 to send an inference request to the deployed model.
 
 ```bash
-curl -X POST localhost:8000/v2/models/ensemble/generate -d '{"text_input": "What is ML?", "max_tokens": 50, "bad_words": "", "stop_words": "", "pad_id": 2, "end_id": 2}'
+curl -X POST localhost:8000/v2/models/llama-2-7b/generate -d '{"text_input": "What is ML?", "max_tokens": 50, "bad_words": "", "stop_words": "", "pad_id": 2, "end_id": 2}'
 ```
 > You should expect the following response:
 > ```

--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,23 +28,36 @@
 
 TensorRT-LLM is Nvidia's recommended solution of running Large Language
 Models(LLMs) on Nvidia GPUs. Read more about TensoRT-LLM [here](https://github.com/NVIDIA/TensorRT-LLM)
-and Triton's TensorRTLLM Backend [here](https://github.com/triton-inference-server/tensorrtllm_backend).
+and Triton's TensorRT-LLM Backend [here](https://github.com/triton-inference-server/tensorrtllm_backend).
 
 *NOTE:* If some parts of this tutorial doesn't work, it is possible that there
-are some version mismatches between the `tutorials` and `tensorrt_backend` repository.
-Refer to [llama.md](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/docs/llama.md)
-for more detailed modifications if necessary. And if you are familier with python, you can also try using [High-level API](https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/high-level-api/README.md) for LLM workflow.
+are some version mismatches between the `tutorials` and `tensorrt_backend`
+repository. Refer to [llama.md](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/docs/llama.md)
+for more detailed modifications if necessary. And if you are familiar with
+python, you can also try using
+[High-level API](https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/high-level-api/README.md)
+for LLM workflow.
 
 
-## Pre-build instructions
+## Acquiring Llama2-7B model
 
-For this tutorial, we are using the Llama2-7B HuggingFace model with pre-trained weights.
-Clone the repo of the model with weights and tokens [here](https://huggingface.co/meta-llama/Llama-2-7b-hf/tree/main).
-You will need to get permissions for the Llama2 repository as well as get access to the huggingface cli. To get access to the huggingface cli, go here: [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens).
+For this tutorial, we are using the Llama2-7B HuggingFace model with pre-trained
+weights. Clone the repo of the model with weights and tokens
+[here](https://huggingface.co/meta-llama/Llama-2-7b-hf/tree/main).
+You will need to get permissions for the Llama2 repository as well as get access
+to the huggingface cli. To get access to the huggingface cli,
+go here: [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens).
 
-## Installation
+## Prerequisite: TensorRT-LLM backend
 
-1. The installation starts with cloning the TensorRT-LLM Backend and update the TensorRT-LLM submodule:
+This tutorial requires TensorRT-LLM Backend repository. Please note,
+that for best user experience we recommend using the latest
+[release tag](https://github.com/triton-inference-server/tensorrtllm_backend/tags)
+of `tensorrtllm_backend` and
+the latest [Triton Server container.](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver/tags)
+
+To clone TensorRT-LLM Backend repository, make sure to run the following
+set of commands.
 ```bash
 git clone https://github.com/triton-inference-server/tensorrtllm_backend.git  --branch <release branch>
 # Update the submodules
@@ -55,102 +68,140 @@ git lfs install
 git submodule update --init --recursive
 ```
 
-2. Launch Triton docker container with TensorRT-LLM backend. Note I'm mounting `tensorrtllm_backend` to `/tensorrtllm_backend` and the Llama2 model to `/Llama-2-7b-hf` in the docker container for simplicity. Make an `engines` folder outside docker to reuse engines for future runs.
+## Launch Triton TensorRT-LLM container
+
+Launch Triton docker container with TensorRT-LLM backend.
+Note that we're mounting `tensorrtllm_backend` to `/tensorrtllm_backend`
+and the Llama2 model to `/Llama-2-7b-hf` in the docker container for simplicity.
+Make an `engines` folder outside docker to reuse engines for future runs.
+Please, make sure to replace <xx.yy> with the version of Triton that you want
+to use.
+
 ```bash
 docker run --rm -it --net host --shm-size=2g \
     --ulimit memlock=-1 --ulimit stack=67108864 --gpus all \
-    -v /path/to/tensorrtllm_backend:/tensorrtllm_backend \
-    -v /path/to/Llama2/repo:/Llama-2-7b-hf \
-    -v /path/to/engines:/engines \
-    nvcr.io/nvidia/tritonserver:23.10-trtllm-python-py3
+    -v </path/to/tensorrtllm_backend>:/tensorrtllm_backend \
+    -v </path/to/Llama2/repo>:/Llama-2-7b-hf \
+    -v </path/to/engines>:/engines \
+    nvcr.io/nvidia/tritonserver:<xx.yy>-trtllm-python-py3
 ```
 
-Alternatively, you can follow instructions [here](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/README.md) to build Triton Server with Tensorrt-LLM Backend if you want to build a specialized container.
+Alternatively, you can follow instructions
+[here](https://github.com/triton-inference-server/tensorrtllm_backend?tab=readme-ov-file#build-the-docker-container)
+to build Triton Server with Tensorrt-LLM Backend if you want
+to build a specialized container.
 
 Don't forget to allow gpu usage when you launch the container.
 
+> Optional: For simplicity, we've condenced all following steps into
+> a [deploy_trtllm_llama.sh](tutorials/Popular_Models_Guide/Llama2/deploy_trtllm_llama.sh).
+> Make sure to clone tutorials repo to your machine and start the docker
+> container with the tutorial repo mounted to `/tutorials` by adding
+> `-v /path/to/tutorials/:/tutorials` to docker run command, listed above.
+> Then, when container has started, simply run the script via
+> ```bash
+> /tutorials/Popular_Models_Guide/Llama2/deploy_trtllm_llama.sh <world size>
+> ```
+> For how to run an inference request, refer to the [Client](#client) section
+> of this tutorial.
+
 ## Create Engines for each model [skip this step if you already have an engine]
-TensorRT-LLM requires each model to be compiled for the configuration you need before running. To do so, before you run your model for the first time on Triton Server you will need to create a TensorRT-LLM engine for the model for the configuration you want with the following steps:
 
-1. Install Tensorrt-LLM python package
-   ```bash
-    # Install CMake
-    bash /tensorrtllm_backend/tensorrt_llm/docker/common/install_cmake.sh
-    export PATH="/usr/local/cmake/bin:${PATH}"
+TensorRT-LLM requires each model to be compiled for the configuration
+you need before running. To do so, before you run your model for the first time
+on Triton Server you will need to create a TensorRT-LLM engine.
 
-    # PyTorch needs to be built from source for aarch64
-    ARCH="$(uname -i)"
-    if [ "${ARCH}" = "aarch64" ]; then TORCH_INSTALL_TYPE="src_non_cxx11_abi"; \
-    else TORCH_INSTALL_TYPE="pypi"; fi && \
-    (cd /tensorrtllm_backend/tensorrt_llm &&
-        bash docker/common/install_pytorch.sh $TORCH_INSTALL_TYPE &&
-        python3 ./scripts/build_wheel.py --trt_root=/usr/local/tensorrt &&
-        pip3 install ./build/tensorrt_llm*.whl)
-    ```
+Starting with 24.04 release, Triton Server TensrRT LLM container comes with
+pre-installed TensorRT-LLM package, which allows users to build engines inside
+the Triton container. Simply follow the next steps:
 
-2.  Compile model engines
-
-    The script to build Llama models is located in [TensorRT-LLM repository](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples). We use the one located in the docker container as `/tensorrtllm_backend/tensorrt_llm/examples/llama/build.py`.
-    This command compiles the model with inflight batching and 1 GPU. To run with more GPUs, you will need to change the build command to use `--world_size X`.
-    More details for the scripting please see the documentation for the Llama example [here](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/llama/README.md).
-
-    ```bash
-    python /tensorrtllm_backend/tensorrt_llm/examples/llama/build.py --model_dir /Llama-2-7b-hf/ \
-                    --dtype bfloat16 \
-                    --use_gpt_attention_plugin bfloat16 \
-                    --use_inflight_batching \
-                    --paged_kv_cache \
-                    --remove_input_padding \
-                    --use_gemm_plugin bfloat16 \
-                    --output_dir /engines/1-gpu/ \
-                    --world_size 1
-    ```
-
-    > Optional: You can check test the output of the model with `run.py`
-    > located in the same llama examples folder.
-    >
-    >   ```bash
-    >    python3 /tensorrtllm_backend/tensorrt_llm/examples/llama/run.py --engine_dir=/engines/1-gpu/ --max_output_len 100 --tokenizer_dir /Llama-2-7b-hf --input_text "How do I count to ten in French?"
-    >    ```
+```bash
+HF_LLAMA_MODEL=/Llama-2-7b-hf
+UNIFIED_CKPT_PATH=/tmp/ckpt/llama/7b/
+ENGINE_PATH=/engines
+CONVERT_CHKPT_SCRIPT=/tensorrtllm_backend/tensorrt_llm/examples/llama/convert_checkpoint.py
+python3 ${CONVERT_CHKPT_SCRIPT} --model_dir ${HF_LLAMA_MODEL} --output_dir ${UNIFIED_CKPT_PATH} --dtype float16
+trtllm-build --checkpoint_dir ${UNIFIED_CKPT_PATH} \
+            --remove_input_padding enable \
+            --gpt_attention_plugin float16 \
+            --context_fmha enable \
+            --gemm_plugin float16 \
+            --output_dir ${ENGINE_PATH} \
+            --paged_kv_cache enable \
+            --max_batch_size 4
+```
+> Optional: You can check test the output of the model with `run.py`
+> located in the same llama examples folder.
+>
+>   ```bash
+>    python3 /tensorrtllm_backend/tensorrt_llm/examples/run.py --engine_dir=/engines/1-gpu/ --max_output_len 50 --tokenizer_dir /Llama-2-7b-hf --input_text "What is ML?"
+>    ```
+> You should expect the following response:
+> ```
+> [TensorRT-LLM] TensorRT-LLM version: 0.9.0
+> ...
+> [TensorRT-LLM][INFO] Max KV cache pages per sequence: 1
+> Input [Text 0]: "<s> What is ML?"
+> Output [Text 0 Beam 0]: "
+> ML is a branch of AI that allows computers to learn from data, identify patterns, and make predictions. It is a powerful tool that can be used in a variety of industries, including healthcare, finance, and transportation."
+> ```
 
 ## Serving with Triton
 
 The last step is to create a Triton readable model. You can
-find a template of a model that uses inflight batching in [tensorrtllm_backend/all_models/inflight_batcher_llm](https://github.com/triton-inference-server/tensorrtllm_backend/tree/main/all_models/inflight_batcher_llm).
+find a template of a model that uses inflight batching in
+[tensorrtllm_backend/all_models/inflight_batcher_llm](https://github.com/triton-inference-server/tensorrtllm_backend/tree/main/all_models/inflight_batcher_llm).
 To run our Llama2-7B model, you will need to:
 
 
 1. Copy over the inflight batcher models repository
 
- ```bash
- cp -R /tensorrtllm_backend/all_models/inflight_batcher_llm /opt/tritonserver/.
- ```
+```bash
+cp -R /tensorrtllm_backend/all_models/inflight_batcher_llm /opt/tritonserver/.
+```
 
-2. Modify config.pbtxt for the preprocessing, postprocessing and processing steps. The following script do a minimized configuration to run tritonserver, but if you want optimal performance or custom parameters, read details in [documentation](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/docs/llama.md) and [perf_best_practices](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/perf_best_practices.md):
+2. Modify config.pbtxt for the preprocessing, postprocessing and processing
+steps. The following script do a minimized configuration to run tritonserver,
+but if you want optimal performance or custom parameters, read details in
+[documentation](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/docs/llama.md)
+and [perf_best_practices](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/performance/perf-best-practices.md):
 
-    ```bash
-    # preprocessing
-    TOKENIZER_DIR=/Llama-2-7b-hf/
-    TOKENIZER_TYPE=auto
-    DECOUPLED_MODE=false
-    ENGINE_DIR=/engines/1-gpu/
-    MODEL_FOLDER=/opt/tritonserver/inflight_batcher_llm
-    MAX_BATCH_SIZE=64
-    FILL_TEMPLATE_SCRIPT=/tensorrtllm_backend/tools/fill_template.py
-    python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/preprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE}
-    python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/postprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE}
-    python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm_bls/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE}
-    python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/ensemble/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE}
-    python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},engine_dir:${ENGINE_DIR}
-    ```
-    Also, ensure that the `gpt_model_type` parameter is set to `inflight_fused_batching`.
+```bash
+# preprocessing
+TOKENIZER_DIR=/Llama-2-7b-hf/
+TOKENIZER_TYPE=auto
+DECOUPLED_MODE=false
+ENGINE_DIR=/engines/1-gpu/
+MODEL_FOLDER=/opt/tritonserver/inflight_batcher_llm
+MAX_BATCH_SIZE=4
+INSTANCE_COUNT=1
+MAX_QUEUE_DELAY_MS=10000
+FILL_TEMPLATE_SCRIPT=/tensorrtllm_backend/tools/fill_template.py
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/preprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE},preprocessing_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/postprocessing/config.pbtxt tokenizer_dir:${TOKENIZER_DIR},tokenizer_type:${TOKENIZER_TYPE},triton_max_batch_size:${MAX_BATCH_SIZE},postprocessing_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm_bls/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},bls_instance_count:${INSTANCE_COUNT}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/ensemble/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE}
+python3 ${FILL_TEMPLATE_SCRIPT} -i ${MODEL_FOLDER}/tensorrt_llm/config.pbtxt triton_max_batch_size:${MAX_BATCH_SIZE},decoupled_mode:${DECOUPLED_MODE},engine_dir:${ENGINE_DIR},max_queue_delay_microseconds:${MAX_QUEUE_DELAY_MS},batching_strategy:inflight_fused_batching
+```
 
 3.  Launch Tritonserver
 
-    Use the [launch_triton_server.py](https://github.com/triton-inference-server/tensorrtllm_backend/blob/release/0.5.0/scripts/launch_triton_server.py) script. This launches multiple instances of `tritonserver` with MPI.
-    ```bash
-    python3 /tensorrtllm_backend/scripts/launch_triton_server.py --world_size=<world size of the engine> --model_repo=/opt/tritonserver/inflight_batcher_llm
-    ```
+Use the [launch_triton_server.py](https://github.com/triton-inference-server/tensorrtllm_backend/blob/release/0.5.0/scripts/launch_triton_server.py) script. This launches multiple instances of `tritonserver` with MPI.
+```bash
+python3 /tensorrtllm_backend/scripts/launch_triton_server.py --world_size=<world size of the engine> --model_repo=/opt/tritonserver/inflight_batcher_llm
+```
+> You should expect the following response:
+> ```
+> ...
+> I0503 22:01:25.210518 1175 grpc_server.cc:2463] Started GRPCInferenceService at 0.0.0.0:8001
+> I0503 22:01:25.211612 1175 http_server.cc:4692] Started HTTPService at 0.0.0.0:8000
+> I0503 22:01:25.254914 1175 http_server.cc:362] Started Metrics Service at 0.0.0.0:8002
+> ```
+
+To stop Triton Server inside the container, run:
+```bash
+pkill tritonserver
+```
 
 ## Client
 
@@ -161,15 +212,32 @@ You can test the results of the run with:
 # Using the SDK container as an example
 docker run --rm -it --net host --shm-size=2g \
     --ulimit memlock=-1 --ulimit stack=67108864 --gpus all \
-    -v /path/to/tensorrtllm_backend:/tensorrtllm_backend \
+    -v /path/to/tensorrtllm_backend/inflight_batcher_llm/client:/tensorrtllm_client \
     -v /path/to/Llama2/repo:/Llama-2-7b-hf \
-    -v /path/to/engines:/engines \
-    nvcr.io/nvidia/tritonserver:23.10-py3-sdk
+    nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
 # Install extra dependencies for the script
 pip3 install transformers sentencepiece
-python3 /tensorrtllm_backend/inflight_batcher_llm/client/inflight_batcher_llm_client.py --request-output-len 200 --tokenizer_type llama --tokenizer_dir /Llama-2-7b-hf
+python3 /tensorrtllm_client/inflight_batcher_llm_client.py --request-output-len 50 --tokenizer-dir /Llama-2-7b-hf/ --text "What is ML?"
 ```
+> You should expect the following response:
+> ```
+> ...
+> Input: What is ML?
+> Output beam 0:
+> ML is a branch of AI that allows computers to learn from data, identify patterns, and make predictions. It is a powerful tool that can be used in a variety of industries, including healthcare, finance, and transportation.
+> ...
+> ```
 
-2. The [generate endpoint](https://github.com/triton-inference-server/tensorrtllm_backend/tree/release/0.5.0#query-the-server-with-the-triton-generate-endpoint) if you are using the Triton TensorRT-LLM Backend container with versions greater than `r23.10`.
+2. The [generate endpoint](https://github.com/triton-inference-server/tensorrtllm_backend/tree/release/0.5.0#query-the-server-with-the-triton-generate-endpoint).
 
+```bash
+curl -X POST localhost:8000/v2/models/ensemble/generate -d '{"text_input": "What is ML?", "max_tokens": 50, "bad_words": "", "stop_words": "", "pad_id": 2, "end_id": 2}'
+```
+> You should expect the following response:
+> ```
+> {"context_logits":0.0,...,"text_output":"What is ML?\nML is a branch of AI that allows computers to learn from data, identify patterns, and make predictions. It is a powerful tool that can be used in a variety of industries, including healthcare, finance, and transportation."}
+> ```
 
+## References
+
+For more examples feel free to refer to [End to end workflow to run llama.](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/docs/llama.md)

--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -111,7 +111,7 @@ TensorRT-LLM requires each model to be compiled for the configuration
 you need before running. To do so, before you run your model for the first time
 on Triton Server you will need to create a TensorRT-LLM engine.
 
-Starting with 24.04 release, Triton Server TensrRT LLM container comes with
+Starting with 24.04 release, Triton Server TensorRT-LLM container comes with
 pre-installed TensorRT-LLM package, which allows users to build engines inside
 the Triton container. Simply follow the next steps:
 

--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -93,7 +93,7 @@ to build a specialized container.
 
 Don't forget to allow gpu usage when you launch the container.
 
-> Optional: For simplicity, we've condenced all following steps into
+> Optional: For simplicity, we've condensed all following steps into
 > a [deploy_trtllm_llama.sh](tutorials/Popular_Models_Guide/Llama2/deploy_trtllm_llama.sh).
 > Make sure to clone tutorials repo to your machine and start the docker
 > container with the tutorial repo mounted to `/tutorials` by adding


### PR DESCRIPTION
I've updated Llama2 TRT-LLM tutorial with instructions for how to build an engine inside the Triton container (started 24.04).

I've also added a bash script, which includes all steps, mentioned in this tutorial. 