### PR TITLE
Update TensorRT repository branch to match TensorRT installed

### DIFF
--- a/Popular_Models_Guide/StableDiffusion/docker/Dockerfile
+++ b/Popular_Models_Guide/StableDiffusion/docker/Dockerfile
@@ -31,7 +31,7 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} as tritonserver-stable-diffusion
 
 RUN pip install --pre --upgrade --extra-index-url https://pypi.nvidia.com tensorrt
 
-RUN git clone https://github.com/NVIDIA/TensorRT.git -b release/9.2 --single-branch /tmp/TensorRT
+RUN git clone https://github.com/NVIDIA/TensorRT.git -b release/10.0 --single-branch /tmp/TensorRT
 
 RUN pip3 install -r /tmp/TensorRT/demo/Diffusion/requirements.txt
 


### PR DESCRIPTION
I tried running the Stable Diffusion example; however, there is a problem with running it due to a TensorRT version mismatch.

The container has installed version 10+. Here is the result of pip list:

```
tensorrt                 10.0.1
tensorrt-cu12            10.0.1
tensorrt-cu12-bindings   10.0.1
tensorrt-cu12-libs       10.0.1
```

But Docker refers to a repository with version 9.

There was a change in the API:

https://docs.nvidia.com/deeplearning/tensorrt/migration-guide/index.html

get_binding_dtype is now get_tensor_dtype.

With version 9, I got this error:

```
tritonserver.InvalidArgumentError: load failed for model 'stable_diffusion_1_5': version 1 is at UNAVAILABLE state: Internal: AttributeError: 'tensorrt_bindings.tensorrt.ICudaEngine' object has no attribute 'get_binding_dtype'

At:
  /opt/tritonserver/backends/diffusion/Diffusion/utilities.py(225): allocate_buffers
  /opt/tritonserver/backends/diffusion/Diffusion/stable_diffusion_pipeline.py(253): loadResources
  /opt/tritonserver/backends/diffusion/model.py(140): initialize
;
```