### PR TITLE
Pin TensorRT Version in Stable Diffusion Tutorial

### DIFF
--- a/Popular_Models_Guide/StableDiffusion/docker/Dockerfile
+++ b/Popular_Models_Guide/StableDiffusion/docker/Dockerfile
@@ -29,7 +29,7 @@ ARG BASE_IMAGE_TAG=24.01-py3
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} as tritonserver-stable-diffusion
 
-RUN pip install --pre --upgrade --extra-index-url https://pypi.nvidia.com tensorrt
+RUN pip install --pre --upgrade --extra-index-url https://pypi.nvidia.com tensorrt==9.2.0.post12.dev5
 
 RUN git clone https://github.com/NVIDIA/TensorRT.git -b release/9.2 --single-branch /tmp/TensorRT
 


### PR DESCRIPTION
SAs have reported issues with the current state of the the tutorial where, when trying to launch a Triton server with the models built in this tutorial, they encounter the following error:

`tritonserver.InvalidArgumentError: load failed for model 'stable_diffusion_xl': version 1 is at UNAVAILABLE state: Internal: AttributeError: 'tensorrt_bindings.tensorrt.ICudaEngine' object has no attribute 'get_binding_dtype'`

Further investigation discovered that the version of TRT being installed in the generated image was `10.2` instead of the intended `9.2`. There is no `9.2.0` version, so we select the latest version available in the `9.2.X` series.

Confirmed both with the SA and through a tutorial walkthrough that this resolves the issue and enables the server to launch and perform inference successfully.