### PR TITLE
Update tutorial to use tokenizer directory for consistency

### DIFF
--- a/Popular_Models_Guide/Llama2/trtllm_guide.md
+++ b/Popular_Models_Guide/Llama2/trtllm_guide.md
@@ -355,7 +355,7 @@ genai-perf \
   --output-tokens-mean 100 \
   --output-tokens-stddev 0 \
   --output-tokens-mean-deterministic \
-  --tokenizer hf-internal-testing/llama-tokenizer \
+  --tokenizer /Llama-2-7b-hf/ \
   --concurrency 1 \
   --measurement-interval 4000 \
   --profile-export-file my_profile_export.json \


### PR DESCRIPTION
Currently, the GenAI-Perf command in the Llama2 TRT-LLM guide uses the Hugging Face tokenizer name. However, the rest of the tutorial uses the tokenizer in the directory located at `/Llama-2-7b-hf/`. Based on user feedback, this PR updates the tutorial to use the filepath instead for consistency.