### PR TITLE
Update README.md. Remove old multinode tutorial

### DIFF
--- a/Deployment/Kubernetes/README.md
+++ b/Deployment/Kubernetes/README.md
@@ -1,4 +1,4 @@
 # Kubernetes Deployment of Triton Server Guides
 
 * [TensorRT-LLM Gen. AI Autoscaling &amp; Load Balancing](./TensorRT-LLM_Autoscaling_and_Load_Balancing/README.md)
-* [Multi-Node Generative AI w/ Triton Server and TensorRT-LLM](./TensorRT-LLM_Multi-Node_Distributed_Models/README.md)
+* [EKS Multinode Triton TRT-LLM](https://github.com/triton-inference-server/tutorials/tree/main/Deployment/Kubernetes/EKS_Multinode_Triton_TRTLLM)


### PR DESCRIPTION
The old multinode tutorial was not useful for our customers. Let's highlight EKS tutorial here.