### PR TITLE
Quick_Deploy: PyTorch: Clarify client.py usage

### DIFF
--- a/Quick_Deploy/PyTorch/README.md
+++ b/Quick_Deploy/PyTorch/README.md
@@ -71,8 +71,10 @@ docker run -it --net=host -v ${PWD}:/workspace/ nvcr.io/nvidia/tritonserver:<yy.
 pip install torchvision
 
 wget  -O img1.jpg "https://www.hakaimagazine.com/wp-content/uploads/header-gulf-birds.jpg"
+python ./client.py
 ```
-Building a client requires three basic points. Firstly, we setup a connection with the Triton Inference Server.
+
+Let's take a look at the contents of `client.py`. Building a client requires three basic points. Firstly, we setup a connection with the Triton Inference Server.
 ```
 client = httpclient.InferenceServerClient(url="localhost:8000")
 ```
@@ -95,4 +97,4 @@ The output of the same should look like below:
 [b'12.468750:90' b'11.523438:92' b'9.664062:14' b'8.429688:136'
  b'8.234375:11']
 ```
-The output format here is `<confidence_score>:<classification_index>`. To learn how to map these to the label names and more, refer to our [documentation](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_classification.md). The client code above is available in `client.py`.
+The output format here is `<confidence_score>:<classification_index>`. To learn how to map these to the label names and more, refer to our [documentation](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_classification.md).


### PR DESCRIPTION
I found following this example difficult because I expected to be able to cut & paste the python code. This doesn't work because we're just looking at snippets of a script, which isn't noted until the end. Make that clear from the start.