### PR TITLE
Fix a error while following tutorial 1

### DIFF
--- a/Conceptual_Guide/Part_1-model_deployment/model_repository/text_recognition/config.pbtxt
+++ b/Conceptual_Guide/Part_1-model_deployment/model_repository/text_recognition/config.pbtxt
@@ -36,7 +36,7 @@ input [
 ]
 output [
   {
-    name: "308"
+    name: "307"
     data_type: TYPE_FP32
     dims: [ 1, 26, 37 ]
   }


### PR DESCRIPTION
When following the tutorial from the link below:

https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/tutorials/Conceptual_Guide/Part_1-model_deployment/README.html#launching-the-server

an error occurs in the config.pbtxt for text_recognition:

"""
failed to load 'text_recognition' version 1: Invalid argument: unexpected inference output '308', allowed outputs are: 307 """

Update config.pbtxt