### PR TITLE
Update README.md for proper link

### DIFF
--- a/Conceptual_Guide/Part_6-building_complex_pipelines/README.md
+++ b/Conceptual_Guide/Part_6-building_complex_pipelines/README.md
@@ -28,7 +28,7 @@
 
 # Building Complex Pipelines: Stable Diffusion
 
-| Navigate to | [Part 5: Building Model Ensembles](../Part_5-Model_Ensembles/) | [Part 7: Iterative Scheduling Tutorial](./Part_7-iterative_scheduling) | [Documentation: BLS](https://github.com/triton-inference-server/python_backend#business-logic-scripting) |
+| Navigate to | [Part 5: Building Model Ensembles](../Part_5-Model_Ensembles/) | [Part 7: Iterative Scheduling Tutorial](../Part_7-iterative_scheduling) | [Documentation: BLS](https://github.com/triton-inference-server/python_backend#business-logic-scripting) |
 | ------------ | --------------- | --------------- |  --------------- |
 
 **Watch [this explainer video](https://youtu.be/JgP2WgNIq_w) with discusses the pipeline, before proceeding with the example**. This example focuses on showcasing two of Triton Inference Server's features:


### PR DESCRIPTION
On [Part 6 ](https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_6-building_complex_pipelines) of the conceptual guide, there was an error in the header link to [Part 7](https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_7-iterative_scheduling) which caused clicking on the header to link to a 404 page. It was linking out to `https://github.com/triton-inference-server/tutorials/blob/main/Conceptual_Guide/Part_6-building_complex_pipelines/Part_7-iterative_scheduling` instead of the proper `https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_7-iterative_scheduling`. I updated the link so that it properly links to the next part.

<img width="1063" height="293" alt="image" src="https://github.com/user-attachments/assets/936a1f72-5d9f-407b-a690-48222a71fc23" />

<img width="1381" height="554" alt="image" src="https://github.com/user-attachments/assets/7a553537-7983-4dba-8138-2714e0f6836d" />
