### PR TITLE
ci: Add centralized add-license pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Get modified files
+      id: modified-files
+      run: echo "modified_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --files ${{ steps.modified-files.outputs.modified_files }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
-- repo: https://github.com/triton-inference-server/pre-commit-hooks
+- repo: https://github.com/triton-inference-server/developer_tools
   rev: v0.1.0
   hooks:
   - id: add-license

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -72,3 +72,8 @@ repos:
   - id: mixed-line-ending
   - id: requirements-txt-fixer
   - id: trailing-whitespace
+
+- repo: https://github.com/triton-inference-server/pre-commit-hooks
+  rev: v0.1.0
+  hooks:
+  - id: add-license

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
Adds the centralized `add-license` pre-commit hook (sourced from `triton-inference-server/pre-commit-hooks`) to this repo's `.pre-commit-config.yaml`, standardizing copyright-header validation/insertion across Triton repos instead of maintaining per-repo copies. The hook also bumps the `LICENSE` copyright year range to 2026.
